### PR TITLE
add a component class for the dynamic template

### DIFF
--- a/addon/components/dynamic-template.js
+++ b/addon/components/dynamic-template.js
@@ -42,6 +42,7 @@ export default Component.extend({
       }
 
       componentName = `some-prefix-${templateId++}`;
+      owner.register(`component:${componentName}`, Component.extend({}))
       owner.register(`template:components/${componentName}`, compiledTemplate);
     }
 


### PR DESCRIPTION
this allows you to be able to access `this` in examples if you have template-only-glimmer-components turned on 👍 