### PR TITLE
Implement indexes

### DIFF
--- a/addon/routes/show.js
+++ b/addon/routes/show.js
@@ -12,6 +12,10 @@ export default class ShowRoute extends Route {
     // remove trailing slash
     let path = params.path.replace(/\/$/, '');
 
+    if (path.endsWith('/index')) {
+      return this.router.transitionTo('show', path.replace(/\/index$/, ''));
+    }
+
     // check if there is a path/index in the TOC
     const toc = this.modelFor('application');
 

--- a/addon/routes/show.js
+++ b/addon/routes/show.js
@@ -3,12 +3,20 @@ import fetch from 'fetch';
 import config from 'ember-get-config';
 import { inject as service } from '@ember/service';
 
+import normalisePath from '../utils/normalise-path';
+
 export default class ShowRoute extends Route {
   @service router;
 
   model(params) {
     // remove trailing slash
     let path = params.path.replace(/\/$/, '');
+
+    // check if there is a path/index in the TOC
+    const toc = this.modelFor('application');
+
+    path = normalisePath(path, toc);
+
     return fetch(`${config.rootURL}docs/${path}.json`)
       .then((res) => res.json())
       .then((res) => {

--- a/addon/utils/normalise-path.js
+++ b/addon/utils/normalise-path.js
@@ -1,0 +1,23 @@
+export default function normalisePath(path, pages) {
+  // walk the structure of the pages object to find any matching indexes
+  function walkPages(path, pages) {
+    if (pages) {
+      if (pages.find((page) => page.id === `${path}/index`)) {
+        return true;
+      }
+
+      // if any of the nested pages have a matching page (recursive)
+      return pages.find((page) => {
+        if (page.pages) {
+          return walkPages(path, page.pages);
+        }
+      });
+    }
+  }
+
+  if (walkPages(path, pages)) {
+    return `${path}/index`;
+  }
+
+  return path;
+}

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,3 @@
+# Concepts
+
+Here is where you lay out all the concepts that you have, because they're great.

--- a/tests/fixtures/toc.js
+++ b/tests/fixtures/toc.js
@@ -1,0 +1,47 @@
+export default [
+  {
+    id: 'index',
+    title: 'index',
+    pages: [],
+  },
+  {
+    id: 'components',
+    title: 'components',
+    pages: [
+      {
+        id: 'components/button',
+        title: 'button',
+      },
+      {
+        id: 'components/custom-button',
+        title: 'custom-button',
+      },
+      {
+        id: 'components/custom-button-glimmer',
+        title: 'custom-button-glimmer',
+      },
+      {
+        id: 'components/link-to',
+        title: 'link-to',
+      },
+    ],
+  },
+  {
+    id: 'concepts',
+    title: 'concepts',
+    pages: [
+      {
+        id: 'concepts/index',
+        title: 'index',
+      },
+      {
+        id: 'concepts/auto-execution',
+        title: 'auto-execution',
+      },
+      {
+        id: 'concepts/colours',
+        title: 'colours',
+      },
+    ],
+  },
+];

--- a/tests/unit/utils/normalise-path-test.js
+++ b/tests/unit/utils/normalise-path-test.js
@@ -1,0 +1,21 @@
+import normalisePath from 'field-guide/utils/normalise-path';
+import { module, test } from 'qunit';
+
+import toc from '../../fixtures/toc';
+
+module('Unit | Utility | normalise-path', function () {
+  test('it works when there is an index', function (assert) {
+    let result = normalisePath('concepts', toc);
+    assert.equal(result, 'concepts/index');
+  });
+
+  test('it doent do anything when there is no index', function (assert) {
+    let result = normalisePath('components', toc);
+    assert.equal(result, 'components');
+  });
+
+  test('it doent do anything when there is a url that doesnt exist in toc', function (assert) {
+    let result = normalisePath('blah', toc);
+    assert.equal(result, 'blah');
+  });
+});


### PR DESCRIPTION
This implements indexes the same way that [guidemaker](https://github.com/empress/guidemaker) does. If you have a folder that has an `index.md` in it then you can navigate to that folder and it will automatically load the data for the `index.md`

this replicates the default behaviour of using an `index.html` in a folder in **most** web servers 👍 