### PR TITLE
Ember 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^6.1.1",
         "ember-resolver": "^8.1.0",
-        "ember-source": "^3.28.0",
+        "ember-source": "~4.4.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^5.3.1",
         "ember-test-selectors": "^6.0.0",
@@ -1323,17 +1323,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-object-assign": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.3.tgz",
-      "integrity": "sha512-kV0CZjCZ3N4DrMnxZwxat6CkeWZTEtDNaW41XbGz5BegV+pu8rKIhJeg50MPk6V+4v496S+pyuDw9PrUwAiuYg==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -2593,9 +2582,9 @@
       "dev": true
     },
     "node_modules/@glimmer/vm-babel-plugins": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.3.tgz",
-      "integrity": "sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.83.1.tgz",
+      "integrity": "sha512-Cz0e/SrOo1gSNA0PXZRYI1WGmlQSAQCpiERBlXjjpwoLgiqx2kvsjfFiCUC/CfpsO6WN6wuPMeTFGJuhSSeL5A==",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
       }
@@ -10284,6 +10273,79 @@
         "node": "10.* || >= 12.*"
       }
     },
+    "node_modules/ember-cli-typescript-blueprint-polyfill": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript-blueprint-polyfill/-/ember-cli-typescript-blueprint-polyfill-0.1.0.tgz",
+      "integrity": "sha512-g0weUTOnHmPGqVZzkQTl3Nbk9fzEdFkEXydCs5mT1qBjXh8eQ6VlmjjGD5/998UXKuA0pLSCVVMbSp/linLzGA==",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "remove-types": "^1.0.0"
+      }
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ember-cli-typescript/node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -12586,39 +12648,39 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "3.28.11",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.28.11.tgz",
-      "integrity": "sha512-oM3X2lYUWJM+CJEdPvJGVZNUTzUAYbDeOOoAJW7im20LkQrv0ce0MAJ1Gf/SnI3H+ZL7lj8qggP+D9P7ZxBvsw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.4.4.tgz",
+      "integrity": "sha512-Ixz7HY4Td2dN78QnuhOafGxW7rYlZuSRdmvCZ0g8Qn1i2RFOZQVU7h81zQj4wFF+ijJdtnfrgG77yBhr7o0gOg==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@babel/plugin-transform-object-assign": "^7.8.3",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-transform-block-scoping": "^7.16.0",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/vm-babel-plugins": "0.80.3",
+        "@glimmer/vm-babel-plugins": "0.83.1",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
-        "broccoli-concat": "^4.2.4",
+        "broccoli-concat": "^4.2.5",
         "broccoli-debug": "^0.6.4",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^2.0.2",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "chalk": "^4.0.0",
-        "ember-cli-babel": "^7.23.0",
+        "ember-auto-import": "^2.4.0",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-version-checker": "^5.1.1",
+        "ember-cli-typescript-blueprint-polyfill": "^0.1.0",
+        "ember-cli-version-checker": "^5.1.2",
         "ember-router-generator": "^2.0.0",
-        "inflection": "^1.12.0",
-        "jquery": "^3.5.1",
-        "resolve": "^1.17.0",
+        "inflection": "^1.13.2",
+        "resolve": "^1.22.0",
         "semver": "^7.3.4",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": ">= 12.*"
       }
     },
     "node_modules/ember-source-channel-url": {
@@ -12662,29 +12724,6 @@
         "node": "^4.5 || 6.* || >= 7.*"
       }
     },
-    "node_modules/ember-source/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
     "node_modules/ember-source/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -12716,14 +12755,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/ember-source/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/ember-source/node_modules/ember-cli-version-checker": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -12744,11 +12775,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ember-source/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/ember-source/node_modules/resolve-package-path": {
       "version": "3.1.0",
@@ -12785,15 +12811,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ember-source/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
       }
     },
     "node_modules/ember-template-imports": {
@@ -18377,11 +18394,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
-    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -21153,7 +21165,6 @@
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
       "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -21803,7 +21814,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/remove-types/-/remove-types-1.0.0.tgz",
       "integrity": "sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.16.10",
         "@babel/plugin-syntax-decorators": "^7.16.7",
@@ -25994,14 +26004,6 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/plugin-transform-object-assign": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.10.3.tgz",
-      "integrity": "sha512-kV0CZjCZ3N4DrMnxZwxat6CkeWZTEtDNaW41XbGz5BegV+pu8rKIhJeg50MPk6V+4v496S+pyuDw9PrUwAiuYg==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.3"
-      }
-    },
     "@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -26956,9 +26958,9 @@
       "dev": true
     },
     "@glimmer/vm-babel-plugins": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.3.tgz",
-      "integrity": "sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==",
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.83.1.tgz",
+      "integrity": "sha512-Cz0e/SrOo1gSNA0PXZRYI1WGmlQSAQCpiERBlXjjpwoLgiqx2kvsjfFiCUC/CfpsO6WN6wuPMeTFGJuhSSeL5A==",
       "requires": {
         "babel-plugin-debug-macros": "^0.3.4"
       }
@@ -34040,6 +34042,60 @@
         }
       }
     },
+    "ember-cli-typescript-blueprint-polyfill": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript-blueprint-polyfill/-/ember-cli-typescript-blueprint-polyfill-0.1.0.tgz",
+      "integrity": "sha512-g0weUTOnHmPGqVZzkQTl3Nbk9fzEdFkEXydCs5mT1qBjXh8eQ6VlmjjGD5/998UXKuA0pLSCVVMbSp/linLzGA==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "remove-types": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "ember-cli-version-checker": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
@@ -34975,34 +35031,34 @@
       }
     },
     "ember-source": {
-      "version": "3.28.11",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.28.11.tgz",
-      "integrity": "sha512-oM3X2lYUWJM+CJEdPvJGVZNUTzUAYbDeOOoAJW7im20LkQrv0ce0MAJ1Gf/SnI3H+ZL7lj8qggP+D9P7ZxBvsw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-4.4.4.tgz",
+      "integrity": "sha512-Ixz7HY4Td2dN78QnuhOafGxW7rYlZuSRdmvCZ0g8Qn1i2RFOZQVU7h81zQj4wFF+ijJdtnfrgG77yBhr7o0gOg==",
       "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@babel/plugin-transform-object-assign": "^7.8.3",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/plugin-transform-block-scoping": "^7.16.0",
         "@ember/edition-utils": "^1.2.0",
-        "@glimmer/vm-babel-plugins": "0.80.3",
+        "@glimmer/vm-babel-plugins": "0.83.1",
         "babel-plugin-debug-macros": "^0.3.4",
         "babel-plugin-filter-imports": "^4.0.0",
-        "broccoli-concat": "^4.2.4",
+        "broccoli-concat": "^4.2.5",
         "broccoli-debug": "^0.6.4",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^2.0.2",
+        "broccoli-funnel": "^3.0.8",
         "broccoli-merge-trees": "^4.2.0",
         "chalk": "^4.0.0",
-        "ember-cli-babel": "^7.23.0",
+        "ember-auto-import": "^2.4.0",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-version-checker": "^5.1.1",
+        "ember-cli-typescript-blueprint-polyfill": "^0.1.0",
+        "ember-cli-version-checker": "^5.1.2",
         "ember-router-generator": "^2.0.0",
-        "inflection": "^1.12.0",
-        "jquery": "^3.5.1",
-        "resolve": "^1.17.0",
+        "inflection": "^1.13.2",
+        "resolve": "^1.22.0",
         "semver": "^7.3.4",
         "silent-error": "^1.1.1"
       },
@@ -35022,26 +35078,6 @@
           "requires": {
             "broccoli-plugin": "^1.1.0",
             "mkdirp": "^0.5.1"
-          }
-        },
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
           }
         },
         "chalk": {
@@ -35066,14 +35102,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "ember-cli-version-checker": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -35088,11 +35116,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "resolve-package-path": {
           "version": "3.1.0",
@@ -35117,15 +35140,6 @@
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "walk-sync": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-          "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-          "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
           }
         }
       }
@@ -39410,11 +39424,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -41635,8 +41644,7 @@
     "prettier": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-      "dev": true
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -42134,7 +42142,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/remove-types/-/remove-types-1.0.0.tgz",
       "integrity": "sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.16.10",
         "@babel/plugin-syntax-decorators": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.1.1",
     "ember-resolver": "^8.1.0",
-    "ember-source": "^3.28.0",
+    "ember-source": "~4.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^5.3.1",
     "ember-test-selectors": "^6.0.0",


### PR DESCRIPTION
Tests are already passing, so let's go ahead and bump the default version to 4.4